### PR TITLE
Limit critical’s concurrency using tiny-async-pool

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const readdirp = require('readdirp')
 const critical = require('critical')
+const asyncPool = require('tiny-async-pool')
 
 const getHtmlFiles = async (directory) => {
   const files = await readdirp.promise(directory, {
@@ -10,30 +11,36 @@ const getHtmlFiles = async (directory) => {
   return files.map((file) => file.fullPath)
 }
 
+const CRITICAL_CONCURRENCY_LIMIT = 4
+
 module.exports = {
   onPostBuild: async ({ inputs, constants, utils }) => {
     const htmlFiles = await getHtmlFiles(constants.PUBLISH_DIR)
+    const criticalOptions = htmlFiles.map((filePath) => ({
+      base: constants.PUBLISH_DIR,
+      // Overwrite files by passing the same path for `src` and `target`.
+      src: filePath,
+      target: filePath,
+      inline: true,
+      minify: inputs.minify,
+      extract: inputs.extract,
+      dimensions: inputs.dimensions
+    }))
 
     try {
       // Ignore penthouse/puppeteer max listener warnings.
       // See https://github.com/pocketjoso/penthouse/issues/250.
       // One penthouse call is made per page and per screen resolution.
-      process.setMaxListeners(htmlFiles.length * inputs.dimensions.length + 1)
-
-      const inlineCriticalPromises = htmlFiles.map((filePath) =>
-        critical.generate({
-          base: constants.PUBLISH_DIR,
-          // Overwrite files by passing the same path for `src` and `target`.
-          src: filePath,
-          target: filePath,
-          inline: true,
-          minify: inputs.minify,
-          extract: inputs.extract,
-          dimensions: inputs.dimensions
-        })
+      process.setMaxListeners(
+        CRITICAL_CONCURRENCY_LIMIT * inputs.dimensions.length + 1
       )
 
-      await Promise.all(inlineCriticalPromises)
+      await asyncPool(
+        CRITICAL_CONCURRENCY_LIMIT,
+        criticalOptions,
+        critical.generate
+      )
+
       console.log('Critical CSS successfully inlined!')
     } catch (error) {
       return utils.build.failBuild('Failed to inline critical CSS.', { error })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "netlify-plugin-inline-critical-css",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4045,6 +4045,15 @@
         "readable-stream": "2 || 3"
       }
     },
+    "tiny-async-pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.1.0.tgz",
+      "integrity": "sha512-jIglyHF/9QdCC3662m/UMVADE6SlocBDpXdFLMZyiAfrw8MSG1pml7lwRtBMT6L/z4dddAxfzw2lpW2Vm42fyQ==",
+      "requires": {
+        "semver": "^5.5.0",
+        "yaassertion": "^1.0.0"
+      }
+    },
     "to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
@@ -4378,6 +4387,11 @@
       "requires": {
         "cuint": "^0.2.2"
       }
+    },
+    "yaassertion": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/yaassertion/-/yaassertion-1.0.2.tgz",
+      "integrity": "sha512-sBoJBg5vTr3lOpRX0yFD+tz7wv/l2UPMFthag4HGTMPrypBRKerjjS8jiEnNMjcAEtPXjbHiKE0UwRR1W1GXBg=="
     },
     "yargs-parser": {
       "version": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netlify-plugin-inline-critical-css",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A Netlify plugin to extract and inline your critical CSS, built on top of the `critical` package.",
   "license": "MIT",
   "author": "Tom Bonnike (bonniketom@gmail.com)",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "main": "index.js",
   "dependencies": {
     "critical": "^2.0.0-24",
-    "readdirp": "^3.4.0"
+    "readdirp": "^3.4.0",
+    "tiny-async-pool": "^1.1.0"
   }
 }


### PR DESCRIPTION
Should resolve #3. Tried locally on a small project and it works. I might need to adjust the concurrency limit later, but I want to try with 4 for now.